### PR TITLE
gh-pages: automate javadoc generation

### DIFF
--- a/.github/workflows/openapi-update-generate-new-sdk.yml
+++ b/.github/workflows/openapi-update-generate-new-sdk.yml
@@ -82,8 +82,7 @@ jobs:
         if: env.CHANGED == 'true'
         uses: actions/checkout@v4
         with:
-          ref: gh-pages-test  # Test on a temporary gh-pages branch
-
+          ref: gh-pages
       - name: Move Javadoc JAR back to working directory
         if: env.CHANGED == 'true'
         run: |
@@ -109,7 +108,7 @@ jobs:
           cd ../$new_version
           jar -xvf $(basename "$JAR_FILE")
 
-      - name: Append new version to index.html
+      - name: Append new version to index.html files
         if: env.CHANGED == 'true'
         run: |
           sed -i '/<ul>/a \ \ \ \ \ \ \ \ <li><a href="/exoscale4j/javadoc/'"$new_version"'">'"$new_version"'</a></li>' index.html


### PR DESCRIPTION
Automates the generation and versioning of Javadocs:

- Clears the current folder before copying the new Javadoc files to prevent outdated content.
- Automatically generates Javadoc from the latest build and places it in both the current folder and a version-specific folder (e.g., 0.0.x-ALPHA).
- Updates the index.html files (both root and Javadoc directory) to reflect the new version at the top of the list.
Cleanup Process:
