### PR TITLE
documentation: removing the "withHttpInfo" from the README.

### DIFF
--- a/generator/libraries/native/api_doc.mustache
+++ b/generator/libraries/native/api_doc.mustache
@@ -7,7 +7,6 @@ All URIs are relative to *{{basePath}}*
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
 {{#operations}}{{#operation}}| [**{{operationId}}**]({{classname}}.md#{{operationId}}) | **{{httpMethod}}** {{path}} | {{summary}} |
-| [**{{operationId}}WithHttpInfo**]({{classname}}.md#{{operationId}}WithHttpInfo) | **{{httpMethod}}** {{path}} | {{summary}} |
 {{/operation}}{{/operations}}
 
 {{#operations}}
@@ -133,99 +132,6 @@ public class Example {
 {{/responses}}
 {{/responses.0}}
 
-## {{operationId}}WithHttpInfo
-
-{{^vendorExtensions.x-group-parameters}}
-> {{#asyncNative}}CompletableFuture<{{/asyncNative}}ApiResponse<{{{returnType}}}{{^returnType}}Void{{/returnType}}>{{#asyncNative}}>{{/asyncNative}} {{operationId}} {{operationId}}WithHttpInfo({{#allParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/allParams}})
-{{/vendorExtensions.x-group-parameters}}
-{{#vendorExtensions.x-group-parameters}}
-> {{#asyncNative}}CompletableFuture<{{/asyncNative}}ApiResponse<{{{returnType}}}{{^returnType}}Void{{/returnType}}>{{#asyncNative}}>{{/asyncNative}} {{operationId}} {{operationId}}WithHttpInfo({{#hasParams}}{{operationId}}Request{{/hasParams}})
-{{/vendorExtensions.x-group-parameters}}
-
-{{summary}}{{#notes}}
-
-{{.}}{{/notes}}
-
-### Example
-
-```java
-// Import classes:
-import {{{invokerPackage}}}.ApiClient;
-import {{{invokerPackage}}}.ApiException;
-import {{{invokerPackage}}}.ApiResponse;
-import {{{invokerPackage}}}.Configuration;{{#hasAuthMethods}}
-import {{{invokerPackage}}}.auth.*;{{/hasAuthMethods}}
-import {{{invokerPackage}}}.models.*;
-import {{{package}}}.{{{classname}}};{{#vendorExtensions.x-group-parameters}}
-import {{{package}}}.{{{classname}}}.*;{{/vendorExtensions.x-group-parameters}}
-{{#asyncNative}}
-import java.util.concurrent.CompletableFuture;
-{{/asyncNative}}
-
-public class Example {
-    public static void main(String[] args) {
-        ApiClient defaultClient = Configuration.getDefaultApiClient();
-        defaultClient.setBasePath("{{{basePath}}}");
-        {{#hasAuthMethods}}
-        {{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
-        // Configure HTTP basic authorization: {{{name}}}
-        HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication("{{{name}}}");
-        {{{name}}}.setUsername("YOUR USERNAME");
-        {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasicBasic}}{{#isBasicBearer}}
-        // Configure HTTP bearer authorization: {{{name}}}
-        HttpBearerAuth {{{name}}} = (HttpBearerAuth) defaultClient.getAuthentication("{{{name}}}");
-        {{{name}}}.setBearerToken("BEARER TOKEN");{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
-        // Configure API key authorization: {{{name}}}
-        ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
-        {{{name}}}.setApiKey("YOUR API KEY");
-        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-        //{{{name}}}.setApiKeyPrefix("Token");{{/isApiKey}}{{#isOAuth}}
-        // Configure OAuth2 access token for authorization: {{{name}}}
-        OAuth {{{name}}} = (OAuth) defaultClient.getAuthentication("{{{name}}}");
-        {{{name}}}.setAccessToken("YOUR ACCESS TOKEN");{{/isOAuth}}
-        {{/authMethods}}
-        {{/hasAuthMethods}}
-
-        {{{classname}}} apiInstance = new {{{classname}}}(defaultClient);
-        {{#allParams}}
-        {{{dataType}}} {{{paramName}}} = {{{example}}}; // {{{dataType}}} | {{{description}}}
-        {{/allParams}}
-        try {
-            {{^vendorExtensions.x-group-parameters}}
-            {{#asyncNative}}CompletableFuture<{{/asyncNative}}ApiResponse<{{{returnType}}}{{^returnType}}Void{{/returnType}}>{{#asyncNative}}>{{/asyncNative}} response = apiInstance.{{{operationId}}}WithHttpInfo({{#allParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/allParams}});
-            {{/vendorExtensions.x-group-parameters}}
-            {{#vendorExtensions.x-group-parameters}}
-            {{#hasParams}}
-            API{{operationId}}Request request = API{{operationId}}Request.newBuilder(){{#allParams}}
-                .{{paramName}}({{paramName}}){{/allParams}}
-                .build();
-            {{/hasParams}}
-            {{#asyncNative}}CompletableFuture<{{/asyncNative}}ApiResponse<{{{returnType}}}{{^returnType}}Void{{/returnType}}>{{#asyncNative}}>{{/asyncNative}} response = apiInstance.{{{operationId}}}WithHttpInfo({{#hasParams}}request{{/hasParams}});
-            {{/vendorExtensions.x-group-parameters}}
-            System.out.println("Status code: " + response{{#asyncNative}}.get(){{/asyncNative}}.getStatusCode());
-            System.out.println("Response headers: " + response{{#asyncNative}}.get(){{/asyncNative}}.getHeaders());
-            {{#returnType}}
-            System.out.println("Response body: " + response{{#asyncNative}}.get(){{/asyncNative}}.getData());
-            {{/returnType}}
-        {{#asyncNative}}
-        } catch (InterruptedException | ExecutionException e) {
-            ApiException apiException = (ApiException)e.getCause();
-            System.err.println("Exception when calling {{{classname}}}#{{{operationId}}}");
-            System.err.println("Status code: " + apiException.getCode());
-            System.err.println("Response headers: " + apiException.getResponseHeaders());
-            System.err.println("Reason: " + apiException.getResponseBody());
-            e.printStackTrace();
-        {{/asyncNative}}
-        } catch (ApiException e) {
-            System.err.println("Exception when calling {{{classname}}}#{{{operationId}}}");
-            System.err.println("Status code: " + e.getCode());
-            System.err.println("Response headers: " + e.getResponseHeaders());
-            System.err.println("Reason: " + e.getResponseBody());
-            e.printStackTrace();
-        }
-    }
-}
-```
 
 ### Parameters
 


### PR DESCRIPTION
Removes the WithHttpInfo method examples from the API documentation:
- Removed WithHttpInfo method examples from api_doc.mustache.
- Documentation will no longer include the WithHttpInfo variants
- Have been tested and verified that the updated documentation generates correctly without WithHttpInfo examples.