### PR TITLE
workflow: Automate release and SDK versioning

### DIFF
--- a/.github/workflows/openapi-update-generate-new-sdk.yml
+++ b/.github/workflows/openapi-update-generate-new-sdk.yml
@@ -36,7 +36,7 @@ jobs:
           current_version=$(xmlstarlet sel -t -v "//*[local-name()='artifactVersion']" pom.xml)
           echo "Current version: $current_version"
 
-          unique_id=$(date +%Y%m%d%H%M%S)
+          unique_id=$(git rev-parse --short HEAD)
           if [[ "$current_version" == *"SNAPSHOT"* ]]; then
             echo "Current version is a SNAPSHOT."
             base_version=$(echo "$current_version" | sed -E 's/-SNAPSHOT-.*//')

--- a/.github/workflows/openapi-update-generate-new-sdk.yml
+++ b/.github/workflows/openapi-update-generate-new-sdk.yml
@@ -3,7 +3,7 @@ name: Update bundled openapi definition & Generate SDK
 on:
   push:
     branches:
-      - sdk-versioning
+      - elkezza-sdk-versioning # for testing, to be changed to "main" before merging 
   workflow_dispatch:
   schedule:
    - cron: '0 7 * * *'  # At 07:00 every day
@@ -105,7 +105,7 @@ jobs:
         if: env.CHANGED == 'true'
         uses: actions/checkout@v4
         with:
-          ref: gh-pages
+          ref: gh-pages-test  # for testing, to be changed to "gh-pages" before merging 
       - name: Move Javadoc JAR back to working directory
         if: env.CHANGED == 'true'
         run: |

--- a/.github/workflows/openapi-update-generate-new-sdk.yml
+++ b/.github/workflows/openapi-update-generate-new-sdk.yml
@@ -3,7 +3,7 @@ name: Update bundled openapi definition & Generate SDK
 on:
   push:
     branches:
-      - main 
+      - elkezza-sdk-versioning   # change to 'main' before merge
   workflow_dispatch:
   schedule:
    - cron: '0 7 * * *'  # At 07:00 every day
@@ -105,7 +105,7 @@ jobs:
         if: env.CHANGED == 'true'
         uses: actions/checkout@v4
         with:
-          ref: gh-pages
+          ref: gh-pages-test  # change to 'gh-pages' before merge
       - name: Move Javadoc JAR back to working directory
         if: env.CHANGED == 'true'
         run: |

--- a/.github/workflows/openapi-update-generate-new-sdk.yml
+++ b/.github/workflows/openapi-update-generate-new-sdk.yml
@@ -1,9 +1,9 @@
 name: Update bundled openapi definition & Generate SDK
 
 on:
-  push:
-    branches:
-      - main
+  #push:
+    #branches:
+      #- main
   workflow_dispatch:
   schedule:
    - cron: '0 7 * * *'  # At 07:00 every day

--- a/.github/workflows/openapi-update-generate-new-sdk.yml
+++ b/.github/workflows/openapi-update-generate-new-sdk.yml
@@ -1,9 +1,9 @@
 name: Update bundled openapi definition & Generate SDK
 
 on:
- # push:
- #   branches:
- #     - main 
+  push:
+    branches:
+      - main 
   workflow_dispatch:
   schedule:
    - cron: '0 7 * * *'  # At 07:00 every day

--- a/.github/workflows/openapi-update-generate-new-sdk.yml
+++ b/.github/workflows/openapi-update-generate-new-sdk.yml
@@ -3,7 +3,7 @@ name: Update bundled openapi definition & Generate SDK
 on:
   push:
     branches:
-      - main
+      - sdk-versioning
   workflow_dispatch:
   schedule:
    - cron: '0 7 * * *'  # At 07:00 every day
@@ -35,11 +35,34 @@ jobs:
         run: |
           current_version=$(xmlstarlet sel -t -v "//*[local-name()='artifactVersion']" pom.xml)
           echo "Current version: $current_version"
-          IFS='.-' read -r -a parts <<< "$current_version"
-          new_patch=$((parts[2] + 1))
-          new_version="${parts[0]}.${parts[1]}.$new_patch-${parts[3]}"
+
+          unique_id=$(date +%Y%m%d%H%M%S)
+          if [[ "$current_version" == *"SNAPSHOT"* ]]; then
+            echo "Current version is a SNAPSHOT."
+            base_version=$(echo "$current_version" | sed -E 's/-SNAPSHOT-.*//')
+            new_version="${base_version}-SNAPSHOT-${unique_id}"
+          else
+            echo "Current version is the last release."
+            IFS='.-' read -r -a parts <<< "$current_version"'
+            major=${parts[0]}
+            minor=${parts[1]}
+            patch=${parts[2]}
+            qualifier=${parts[3]}
+            
+            new_patch=$((patch + 1))
+
+            if [ -z "$qualifier" ]; then
+              base_version="${major}.${minor}.${new_patch}"
+            else
+              base_version="${major}.${minor}.${new_patch}-${qualifier}"
+            fi
+            
+            new_version="${base_version}-SNAPSHOT-${unique_id}"
+          fi
+
           echo "New version: $new_version"
           xmlstarlet ed --inplace --update "//*[local-name()='artifactVersion']" --value "$new_version" pom.xml
+          
           echo "new_version=$new_version" >> $GITHUB_ENV
           echo "Updated version to $new_version"
 

--- a/.github/workflows/openapi-update-generate-new-sdk.yml
+++ b/.github/workflows/openapi-update-generate-new-sdk.yml
@@ -3,7 +3,7 @@ name: Update bundled openapi definition & Generate SDK
 on:
   push:
     branches:
-      - elkezza-sdk-versioning   # change to 'main' before merge
+      - main
   workflow_dispatch:
   schedule:
    - cron: '0 7 * * *'  # At 07:00 every day
@@ -105,7 +105,7 @@ jobs:
         if: env.CHANGED == 'true'
         uses: actions/checkout@v4
         with:
-          ref: gh-pages-test  # change to 'gh-pages' before merge
+          ref: gh-pages
       - name: Move Javadoc JAR back to working directory
         if: env.CHANGED == 'true'
         run: |

--- a/.github/workflows/openapi-update-generate-new-sdk.yml
+++ b/.github/workflows/openapi-update-generate-new-sdk.yml
@@ -1,9 +1,9 @@
 name: Update bundled openapi definition & Generate SDK
 
 on:
-  push:
-    branches:
-      - elkezza-sdk-versioning # for testing, to be changed to "main" before merging 
+ # push:
+ #   branches:
+ #     - main 
   workflow_dispatch:
   schedule:
    - cron: '0 7 * * *'  # At 07:00 every day
@@ -105,7 +105,7 @@ jobs:
         if: env.CHANGED == 'true'
         uses: actions/checkout@v4
         with:
-          ref: gh-pages-test  # for testing, to be changed to "gh-pages" before merging 
+          ref: gh-pages
       - name: Move Javadoc JAR back to working directory
         if: env.CHANGED == 'true'
         run: |

--- a/.github/workflows/openapi-update-generate-new-sdk.yml
+++ b/.github/workflows/openapi-update-generate-new-sdk.yml
@@ -43,7 +43,7 @@ jobs:
             new_version="${base_version}-SNAPSHOT-${unique_id}"
           else
             echo "Current version is the last release."
-            IFS='.-' read -r -a parts <<< "$current_version"'
+            IFS='.-' read -r -a parts <<< "$current_version"
             major=${parts[0]}
             minor=${parts[1]}
             patch=${parts[2]}

--- a/.github/workflows/openapi-update-generate-new-sdk.yml
+++ b/.github/workflows/openapi-update-generate-new-sdk.yml
@@ -94,8 +94,8 @@ jobs:
       - name: Commit and push changes if OpenAPI definition has changed
         if: env.CHANGED == 'true'
         run: |-
-          git config user.name "Automated"
-          git config user.email "actions@users.noreply.github.com"
+          git config user.name "Exoscale"
+          git config user.email "operation+build@exoscale.net"
           git add .
           timestamp=$(date -u)
           git commit -m "OpenAPI spec and SDK update: ${timestamp}" || exit 0
@@ -147,8 +147,8 @@ jobs:
       - name: Commit and push JavaDocs
         if: env.CHANGED == 'true'
         run: |-
-          git config user.name "Automated"
-          git config user.email "actions@users.noreply.github.com"
+          git config user.name "Exoscale"
+          git config user.email "operation+build@exoscale.net"
           git add .
           git commit -m "Update JavaDocs for $new_version"
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,13 @@ jobs:
           ref: elkezza-sdk-versioning  # Change 'main' before the merge
           fetch-depth: 0
 
+
       - name: Install xmlstarlet
         run: sudo apt-get update && sudo apt-get install -y xmlstarlet
 
       - name: Get tag name
         run: |
-          TAG_NAME=${GITHUB_REF##*/}
+          TAG_NAME=${GITHUB_REF#refs/tags/}
           echo "TAG_NAME=$TAG_NAME"
           echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,11 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y xmlstarlet
 
       - name: Get tag name
-        id: tag
         run: |
-          TAG_NAME=$(git describe --tags)
+          TAG_NAME=${GITHUB_REF##*/}
+          echo "TAG_NAME=$TAG_NAME"
           echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+          
       - name: Update version numbers in files
         run: |
           BASE_VERSION=${TAG_NAME#v}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,9 @@ jobs:
 
       - name: Build and install SDK
         run: |
-          mvn clean install
+          mvn -B clean process-resources --no-transfer-progress --file pom.xml
           cd sdk
-          mvn install
+          mvn -B install --no-transfer-progress --file pom.xml -Dmaven.test.skip=true -X
           cd ..
           
       - name: Check target folder for JavaDocs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG_NAME=$(git describe --tags)
           RELEASE_TITLE="Release ${TAG_NAME}"
-          RELEASE_NOTES="See the [CHANGELOG](https://github.com/exoscale/exoscale4j/blob/main/CHANGELOG.md) for details."
+          RELEASE_NOTES="See the [CHANGELOG](https://github.com/exoscale/exoscale-sdk-java/blob/main/CHANGELOG.md) for details."
           gh release create "${TAG_NAME}" --title "${RELEASE_TITLE}" --notes "${RELEASE_NOTES}"
 
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,36 @@ jobs:
           cd sdk
           mvn -B install --no-transfer-progress --file pom.xml -Dmaven.test.skip=true -X
           cd ..
+
+          
+      # Set up JDK 11
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          server-id: 'central'
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_KEYRING }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          
+      - name: Publish package
+        run: mvn --batch-mode deploy --file sdk/pom.xml -Psign-artifacts
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD}}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME=$(git describe --tags)
+          RELEASE_TITLE="Release ${TAG_NAME}"
+          RELEASE_NOTES="See the [CHANGELOG](https://github.com/exoscale/exoscale4j/blob/main/CHANGELOG.md) for details."
+          gh release create "${TAG_NAME}" --title "${RELEASE_TITLE}" --notes "${RELEASE_NOTES}"
+
           
       - name: Check target folder for JavaDocs
         run: ls -lR sdk/target/
@@ -112,31 +142,3 @@ jobs:
           git add .
           git commit -m "Update JavaDocs for $BASE_VERSION"
           git push
-
-    
-      # Set up JDK 11
-      - name: Set up JDK 11
-        uses: actions/setup-java@v4
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-          server-id: 'central'
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.MAVEN_GPG_KEYRING }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
-      - name: Publish package
-        run: mvn --batch-mode deploy --file sdk/pom.xml -Psign-artifacts
-        env:
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD}}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-
-      - name: Create GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG_NAME=$(git describe --tags)
-          RELEASE_TITLE="Release ${TAG_NAME}"
-          RELEASE_NOTES="See the [CHANGELOG](https://github.com/exoscale/exoscale4j/blob/main/CHANGELOG.md) for details."
-          gh release create "${TAG_NAME}" --title "${RELEASE_TITLE}" --notes "${RELEASE_NOTES}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Checkout gh-pages branch
         uses: actions/checkout@v4
         with:
-          ref: gh-pages
+          ref: gh-pages-test #change to 'main' before merge
           
       - name: Move Javadoc JAR back to working directory
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           git config user.name "Automated"
           git config user.email "actions@users.noreply.github.com"
           git add pom.xml README.md "$CONFIG_FILE"
-          git commit -m "Update version to $BASE_VERSION for release"
+          git commit -m "Update version to $BASE_VERSION for release" || true
           git push
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,17 @@ jobs:
           sed -i "s/<version>.*<\/version>/<version>$BASE_VERSION<\/version>/g" README.md
           sed -i "s/'com.exoscale.sdk:sdk:.*'/'com.exoscale.sdk:sdk:$BASE_VERSION'/g" README.md
 
+          
+          sed -i "s/<version>.*<\/version>/<version>$BASE_VERSION<\/version>/g" sdk/README.md
+          sed -i "s/'com.exoscale.sdk:sdk:.*'/'com.exoscale.sdk:sdk:$BASE_VERSION'/g" sdk/README.md
+
+
           CONFIG_FILE="sdk/src/main/java/com/exoscale/sdk/client/Configuration.java"
           sed -i "s/public static final String VERSION = \".*\";/public static final String VERSION = \"$BASE_VERSION\";/g" "$CONFIG_FILE"
 
           git config user.name "Automated"
           git config user.email "actions@users.noreply.github.com"
-          git add pom.xml README.md "$CONFIG_FILE"
+          git add pom.xml README.md sdk/README.md "$CONFIG_FILE"
           git commit -m "Update version to $BASE_VERSION for release" || true
           git push
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,8 @@ jobs:
           CONFIG_FILE="sdk/src/main/java/com/exoscale/sdk/client/Configuration.java"
           sed -i "s/public static final String VERSION = \".*\";/public static final String VERSION = \"$BASE_VERSION\";/g" "$CONFIG_FILE"
 
-          git config user.name "Automated"
-          git config user.email "actions@users.noreply.github.com"
+          git config user.name "Exoscale"
+          git config user.email "operation+build@exoscale.net"
           git add pom.xml README.md sdk/README.md "$CONFIG_FILE"
           git commit -m "Update version to $BASE_VERSION for release" || true
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Checkout gh-pages branch
         uses: actions/checkout@v4
         with:
-          ref: gh-pages-test       # Change to gh-pages before the merge
+          ref: gh-pages
           
       - name: Move Javadoc JAR back to working directory
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,23 +13,107 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: elkezza-sdk-versioning  # Change 'main' before the merge
           fetch-depth: 0
+
+      - name: Install xmlstarlet
+        run: sudo apt-get update && sudo apt-get install -y xmlstarlet
+
+      - name: Get tag name
+        id: tag
+        run: |
+          TAG_NAME=$(git describe --tags)
+          echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+      - name: Update version numbers in files
+        run: |
+          BASE_VERSION=${TAG_NAME#v}
+          echo "Base version: $BASE_VERSION"
+          xmlstarlet ed --inplace --update "//*[local-name()='artifactVersion']" --value "$BASE_VERSION" pom.xml
+
+          sed -i "s/<version>.*<\/version>/<version>$BASE_VERSION<\/version>/g" README.md
+          sed -i "s/'com.exoscale.sdk:sdk:.*'/'com.exoscale.sdk:sdk:$BASE_VERSION'/g" README.md
+
+          CONFIG_FILE="sdk/src/main/java/com/exoscale/sdk/client/Configuration.java"
+          sed -i "s/public static final String VERSION = \".*\";/public static final String VERSION = \"$BASE_VERSION\";/g" "$CONFIG_FILE"
+
+          git config user.name "Automated"
+          git config user.email "actions@users.noreply.github.com"
+          git add pom.xml README.md "$CONFIG_FILE"
+          git commit -m "Update version to $BASE_VERSION for release"
+          git push
+
 
       - name: Set up GitHub CLI
         uses: sersoft-gmbh/setup-gh-cli-action@v2
         with:
           version: stable
 
-      - name: Create GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG_NAME=$(git describe --tags)
-          RELEASE_TITLE="Release ${TAG_NAME}"
-          RELEASE_NOTES="See the [CHANGELOG](https://github.com/exoscale/exoscale4j/blob/main/CHANGELOG.md) for details."
-          gh release create "${TAG_NAME}" --title "${RELEASE_TITLE}" --notes "${RELEASE_NOTES}"
 
+      - name: Build and install SDK
+        run: |
+          mvn clean install
+          cd sdk
+          mvn install
+          cd ..
+          
+      - name: Check target folder for JavaDocs
+        run: ls -lR sdk/target/
+
+      - name: Copy Javadoc JAR to a temporary location
+        run: |
+          echo "Checking target folder for JavaDocs"
+          ls -lR sdk/target/
+          mkdir -p /tmp/javadoc
+          cp sdk/target/*-javadoc.jar /tmp/javadoc/
+
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages-test       # Change to gh-pages before the merge
+          
+      - name: Move Javadoc JAR back to working directory
+        run: |
+          mkdir -p sdk/target/
+          mv /tmp/javadoc/* sdk/target/
+
+      - name: Clean current Javadoc and docs folders before new extraction
+        run: |
+          rm -rf docs/*
+          rm -rf javadoc/current/*
+
+      - name: Extract Javadoc JAR dynamically and create version-specific folder
+        run: |
+          mkdir -p docs
+          mkdir -p javadoc/current
+          mkdir -p javadoc/$BASE_VERSION
+          JAR_FILE=$(find sdk/target -name '*-javadoc.jar' | head -n 1)
+          echo "Found Javadoc JAR: $JAR_FILE"
+          cp "$JAR_FILE" docs/
+          cp "$JAR_FILE" javadoc/current/
+          cp "$JAR_FILE" javadoc/$BASE_VERSION/
+          cd docs/
+          jar -xvf $(basename "$JAR_FILE")
+          cd ..
+          cd javadoc/current
+          jar -xvf $(basename "$JAR_FILE")
+          cd ../$BASE_VERSION
+          jar -xvf $(basename "$JAR_FILE")
+
+      - name: Append new version to index.html files
+        run: |
+          sed -i '/<ul>/a \ \ \ \ \ \ \ \ <li><a href="javadoc/'"$BASE_VERSION"'">'"$BASE_VERSION"'</a></li>' index.html
+          sed -i '/<ul>/a \ \ \ \ \ \ \ \ <li><a href="'$BASE_VERSION'">'"$BASE_VERSION"'</a></li>' javadoc/index.html
+
+
+      - name: Commit and push JavaDocs
+        run: |-
+          git config user.name "Automated"
+          git config user.email "actions@users.noreply.github.com"
+          git add .
+          git commit -m "Update JavaDocs for $BASE_VERSION"
+          git push
+
+    
       # Set up JDK 11
       - name: Set up JDK 11
         uses: actions/setup-java@v4
@@ -47,3 +131,12 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD}}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME=$(git describe --tags)
+          RELEASE_TITLE="Release ${TAG_NAME}"
+          RELEASE_NOTES="See the [CHANGELOG](https://github.com/exoscale/exoscale4j/blob/main/CHANGELOG.md) for details."
+          gh release create "${TAG_NAME}" --title "${RELEASE_TITLE}" --notes "${RELEASE_NOTES}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,8 +144,8 @@ jobs:
 
       - name: Commit and push JavaDocs
         run: |-
-          git config user.name "Automated"
-          git config user.email "actions@users.noreply.github.com"
+          git config user.name "Exoscale"
+          git config user.email "operation+build@exoscale.net"
           git add .
           git commit -m "Update JavaDocs for $BASE_VERSION"
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: elkezza-sdk-versioning  # Change 'main' before the merge
+          ref: main
           fetch-depth: 0
 
 
@@ -105,7 +105,7 @@ jobs:
       - name: Checkout gh-pages branch
         uses: actions/checkout@v4
         with:
-          ref: gh-pages-test #change to 'main' before merge
+          ref: gh-pages
           
       - name: Move Javadoc JAR back to working directory
         run: |

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -8,7 +8,7 @@ info:
     name: API support
     url: https://portal.exoscale.com/tickets
   title: Exoscale Public API
-  description: |2-
+  description: |2- 
 
     Infrastructure automation API, allowing programmatic access to all Exoscale products and services.
 


### PR DESCRIPTION
Updated SDK generation and release workflows to handle versioning correctly.
SDK generation workflow:
- After the changes in the OpenAPI are detected, the `version` is incremented within the `pom.xml`, and `SNAPSH-unique_id` is added to the version in case of the last release, otherwise the `unique_id` only is changed.
E.g `0.0.16-ALPHA` becomes `0.0.17-ALPHA-SNAPSHOT-akjnda1oi313oije1md` in case of the last release otherwise will be`0.0.17-ALPHA-SNAPSHOT-2k1j32ui1221jnduin`.

release workflow:
- In the other hand, delete the `SNAPSH-unique_id` from the version before the new release.
- updated all the files that contain the old version with a new release version.
- push the Javadocs to gh-pages with the last release.

