### PR TITLE
Remove redundant GitHub CLI setup action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,13 +49,6 @@ jobs:
           git commit -m "Update version to $BASE_VERSION for release" || true
           git push
 
-
-      - name: Set up GitHub CLI
-        uses: sersoft-gmbh/setup-gh-cli-action@3cb41a4434ca35de4d1c16e00dc7e16d38409494 # v3.0.0
-        with:
-          version: stable
-
-
       - name: Build and install SDK
         run: |
           mvn -B clean process-resources --no-transfer-progress --file pom.xml


### PR DESCRIPTION
## Summary

- use the GitHub CLI preinstalled on `ubuntu-latest`
- remove the third-party setup action from the release workflow

## Rationale

The release job runs on GitHub-hosted `ubuntu-latest`, whose [runner image includes GitHub CLI](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#cli-tools) on `PATH`. This workflow only uses it for `gh release create` and does not require a specific CLI version, so downloading the mutable `stable` release through a separate setup action adds no needed functionality. If the workflow later requires an exact GitHub CLI version, it can pin and install that version explicitly.

---

> [!NOTE]
> AI assistance: PR description.